### PR TITLE
Added explicit call to purrr for map_chr()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Date: 2017-10-01
 Author: Bob Rudis (bob@rud.is)
 Authors@R: c(
       person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre")),
-      person("Abe", "Neuwirth", role = c("ctb"))
+      person("Abe", "Neuwirth", role = c("ctb")),
+      person("Mike", "Gruszczynski", role = c("ctb"))
     )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: The 'GDELT' Television Explorer (<http://television.gdeltproject.org/cgi-bin/iatv_ftxtsearch/iatv_ftxtsearch>) 

--- a/R/newsflash.r
+++ b/R/newsflash.r
@@ -81,7 +81,7 @@ query_tv <- function(primary_keyword, context_keywords=NULL,
     } else {
 
       if (!is.null(start_date)) {
-        start_date <- map_chr(start_date, function(x) {
+        start_date <- purrr::map_chr(start_date, function(x) {
           if ((is.character(x) && (x != "")) | inherits(x, "Date")) {
             format(as.Date(x), "%m/%d/%Y")
           } else { 
@@ -91,7 +91,7 @@ query_tv <- function(primary_keyword, context_keywords=NULL,
       }
 
       if (!is.null(end_date)) {
-        end_date <- map_chr(end_date, function(x) {
+        end_date <- purrr::map_chr(end_date, function(x) {
           if ((is.character(x) && (x != "")) | inherits(x, "Date")) {
             format(as.Date(x), "%m/%d/%Y")
           } else {


### PR DESCRIPTION
The call to `map_chr()` for parameters `start_date` and `end_date` doesn't work without the package `purrr` being imported completely. As per [Hadley Wickham's recommendations](https://cran.r-project.org/web/packages/roxygen2/vignettes/namespace.html), I added an explicit call to `purrr` rather than adding in an `importfrom` statement in the package import file.